### PR TITLE
fix: correct ProductModelsPool resource mixins

### DIFF
--- a/pyakeneo/resources.py
+++ b/pyakeneo/resources.py
@@ -172,11 +172,13 @@ class ProductsPool(
 
 class ProductModelsPool(
     ResourcePool,
-    IdentifierBasedResource,
+    CodeBasedResource,
     CreatableResource,
+    DeletableResource,
     GettableResource,
     SearchAfterListableResource,
     UpdatableResource,
+    UpdatableListResource,
 ):
     """https://api.akeneo.com/api-reference.html#Productmodel"""
 


### PR DESCRIPTION
## Summary
- Replace `IdentifierBasedResource` with `CodeBasedResource` (product models use codes, not identifiers)
- Add missing `DeletableResource` and `UpdatableListResource` mixins